### PR TITLE
(refactor): KHP3-6501 - Move stockItem property from ItemPrice to BillableService data model

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/impl/ItemPriceServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/impl/ItemPriceServiceImpl.java
@@ -55,14 +55,10 @@ public class ItemPriceServiceImpl extends BaseEntityDataServiceImpl<CashierItemP
 
 	@Override
 	public List<CashierItemPrice> getItemPrice(StockItem stockItem) {
-		// Criteria criteria = getRepository().createCriteria(getEntityClass());
 		Criteria criteria = getRepository().createCriteria(CashierItemPrice.class);
 
 		criteria.add(Restrictions.eq("item", stockItem));
 		criteria.addOrder(Order.desc("id"));
-
-		// List<ItemPrice> results = getRepository().select(getEntityClass(), criteria);
-		// return(results);
 		return criteria.list();
 	}
 

--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/impl/ItemPriceServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/impl/ItemPriceServiceImpl.java
@@ -1,17 +1,21 @@
 package org.openmrs.module.kenyaemr.cashier.api.impl;
 
-import java.util.List;
-
 import org.hibernate.Criteria;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Restrictions;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.db.hibernate.DbSession;
 import org.openmrs.module.kenyaemr.cashier.api.ItemPriceService;
 import org.openmrs.module.kenyaemr.cashier.api.base.entity.impl.BaseEntityDataServiceImpl;
 import org.openmrs.module.kenyaemr.cashier.api.base.entity.security.IEntityAuthorizationPrivileges;
 import org.openmrs.module.kenyaemr.cashier.api.model.BillableService;
+import org.openmrs.module.kenyaemr.cashier.api.model.BillableServiceStatus;
 import org.openmrs.module.kenyaemr.cashier.api.model.CashierItemPrice;
 import org.openmrs.module.stockmanagement.api.model.StockItem;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Transactional
 public class ItemPriceServiceImpl extends BaseEntityDataServiceImpl<CashierItemPrice> implements IEntityAuthorizationPrivileges
@@ -55,11 +59,14 @@ public class ItemPriceServiceImpl extends BaseEntityDataServiceImpl<CashierItemP
 
 	@Override
 	public List<CashierItemPrice> getItemPrice(StockItem stockItem) {
-		Criteria criteria = getRepository().createCriteria(CashierItemPrice.class);
-
-		criteria.add(Restrictions.eq("item", stockItem));
-		criteria.addOrder(Order.desc("id"));
-		return criteria.list();
+		Criteria criteria = getRepository().createCriteria(BillableService.class);
+		criteria.add(Restrictions.eq("stockItem", stockItem));
+		criteria.add(Restrictions.eq("serviceStatus", BillableServiceStatus.ENABLED));
+		List<BillableService> results = criteria.list();
+		if (results.size() > 0) {
+			return results.get(0).getServicePrices();
+		}
+		return new ArrayList<>();
 	}
 
 	@Override

--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/model/BillableService.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/model/BillableService.java
@@ -2,10 +2,15 @@ package org.openmrs.module.kenyaemr.cashier.api.model;
 
 import org.openmrs.BaseOpenmrsData;
 import org.openmrs.Concept;
+import org.openmrs.module.stockmanagement.api.model.StockItem;
 
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * This has been expanded to manage pricing of both services and commodity.
+ * For commodity, the stockItem property is specified and this links to a commodity in the stock management module
+ */
 public class BillableService extends BaseOpenmrsData {
 
     public static final long serialVersionUID = 0L;
@@ -15,6 +20,7 @@ public class BillableService extends BaseOpenmrsData {
     private String shortName;
     private Concept concept;
     private Concept serviceType;
+    private StockItem stockItem;
     private Concept serviceCategory;
     private List<CashierItemPrice> servicePrices;
     private BillableServiceStatus serviceStatus = BillableServiceStatus.ENABLED;
@@ -88,6 +94,14 @@ public class BillableService extends BaseOpenmrsData {
 
     public Concept getConcept() {
         return concept;
+    }
+
+    public StockItem getStockItem() {
+        return stockItem;
+    }
+
+    public void setStockItem(StockItem stockItem) {
+        this.stockItem = stockItem;
     }
 
     public void setConcept(Concept concept) {

--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/model/CashierItemPrice.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/model/CashierItemPrice.java
@@ -13,7 +13,6 @@ public class CashierItemPrice extends BaseOpenmrsData {
 	private String name;
 	private BigDecimal price;
 	private PaymentMode paymentMode;
-	private StockItem item;
 	private BillableService billableService;
 
 	public CashierItemPrice() {
@@ -23,7 +22,6 @@ public class CashierItemPrice extends BaseOpenmrsData {
 	public CashierItemPrice(String name, BigDecimal price, StockItem item, BillableService billableService) {
 		this.name = name;
 		this.price = price;
-		this.item = item;
 		this.billableService = billableService;
 	}
 
@@ -50,14 +48,6 @@ public class CashierItemPrice extends BaseOpenmrsData {
 
 	public void setPaymentMode(PaymentMode paymentMode) {
 		this.paymentMode = paymentMode;
-	}
-
-	public StockItem getItem() {
-		return item;
-	}
-
-	public void setItem(StockItem item) {
-		this.item = item;
 	}
 
 	public BigDecimal getPrice() {

--- a/api/src/main/resources/Bill.hbm.xml
+++ b/api/src/main/resources/Bill.hbm.xml
@@ -12,8 +12,6 @@
 			</generator>
 		</id>
 		<discriminator column="item_price_id" insert="false" />
-
-		<many-to-one name="item" class="org.openmrs.module.stockmanagement.api.model.StockItem" not-null="false" column="item_id" />
 		<many-to-one name="billableService" class="org.openmrs.module.kenyaemr.cashier.api.model.BillableService" not-null="false" column="service_id" />
 		<many-to-one name="paymentMode" class="org.openmrs.module.kenyaemr.cashier.api.model.PaymentMode" not-null="false" column="payment_mode" />
 
@@ -48,7 +46,7 @@
 		<property name="name" type="java.lang.String" column="name" not-null="true" length="19" />
 		<property name="shortName" type="java.lang.String" column="short_name" length="19" />
 		<many-to-one name="concept" class="org.openmrs.Concept"  not-null="false"  column="concept_id"/>
-
+		<many-to-one name="stockItem" class="org.openmrs.module.stockmanagement.api.model.StockItem" not-null="false" column="stock_item_id" />
 		<many-to-one name="serviceType" class="org.openmrs.Concept" not-null="false" column="service_type" />
 		<many-to-one name="serviceCategory" class="org.openmrs.Concept" not-null="false" column="service_category" />
 

--- a/omod/src/main/java/org/openmrs/module/kenyaemr/cashier/rest/resource/CashierItemPriceResource.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/cashier/rest/resource/CashierItemPriceResource.java
@@ -46,7 +46,6 @@ public class CashierItemPriceResource extends BaseRestDataResource<CashierItemPr
             description.addProperty("name");
             description.addProperty("price");
             description.addProperty("paymentMode");
-            description.addProperty("item");
             description.addProperty("billableService", Representation.REF);
         } else if (rep instanceof CustomRepresentation) {
             //For custom representation, must be null
@@ -61,7 +60,6 @@ public class CashierItemPriceResource extends BaseRestDataResource<CashierItemPr
         description.addProperty("name");
         description.addProperty("price");
         description.addProperty("paymentMode");
-        description.addProperty("item");
         description.addProperty("billableService");
         return description;
     }
@@ -80,23 +78,6 @@ public class CashierItemPriceResource extends BaseRestDataResource<CashierItemPr
             instance.setPrice(BigDecimal.valueOf(amount));
         } else {
             instance.setPrice(BigDecimal.valueOf((Double) price));
-        }
-    }
-
-    @PropertySetter(value = "item")
-    public void setItem(CashierItemPrice instance, Object item) {
-        StockManagementService service = Context.getService(StockManagementService.class);
-        String itemUuid = (String) item;
-        instance.setItem(service.getStockItemByUuid(itemUuid));
-    }
-    @PropertyGetter(value = "item")
-    public String getItem(CashierItemPrice instance) {
-        try {
-            StockItem stockItem = instance.getItem();
-            return stockItem.getConcept().getDisplayString();
-        } catch (Exception e) {
-            System.out.println("Item probably was deleted");
-            return "";
         }
     }
 }

--- a/omod/src/main/java/org/openmrs/module/kenyaemr/cashier/rest/restmapper/BillableServiceMapper.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/cashier/rest/restmapper/BillableServiceMapper.java
@@ -1,11 +1,13 @@
 package org.openmrs.module.kenyaemr.cashier.rest.restmapper;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.kenyaemr.cashier.api.IBillableItemsService;
 import org.openmrs.module.kenyaemr.cashier.api.IPaymentModeService;
 import org.openmrs.module.kenyaemr.cashier.api.model.BillableService;
 import org.openmrs.module.kenyaemr.cashier.api.model.BillableServiceStatus;
 import org.openmrs.module.kenyaemr.cashier.api.model.CashierItemPrice;
+import org.openmrs.module.stockmanagement.api.StockManagementService;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -19,6 +21,7 @@ public class BillableServiceMapper {
     private String concept;
     private String serviceType;
     private String serviceCategory;
+    private String stockItem;
     private List<CashierItemPriceMapper> servicePrices;
     private BillableServiceStatus serviceStatus = BillableServiceStatus.ENABLED;
     private String uuid;
@@ -79,6 +82,14 @@ public class BillableServiceMapper {
         this.concept = concept;
     }
 
+    public String getStockItem() {
+        return stockItem;
+    }
+
+    public void setStockItem(String stockItem) {
+        this.stockItem = stockItem;
+    }
+
     public String getUuid() {
         return uuid;
     }
@@ -95,6 +106,9 @@ public class BillableServiceMapper {
         service.setServiceType(Context.getConceptService().getConceptByUuid(mapper.getServiceType()));
         service.setServiceCategory(Context.getConceptService().getConceptByUuid(mapper.getServiceCategory()));
         service.setServiceStatus(mapper.getServiceStatus());
+        if (StringUtils.isNotBlank(mapper.getStockItem())) {
+            service.setStockItem(Context.getService(StockManagementService.class).getStockItemByUuid(mapper.getStockItem()));
+        }
         for (CashierItemPriceMapper itemPrice : mapper.getServicePrices()) {
             CashierItemPrice price = new CashierItemPrice();
             price.setName(itemPrice.getName());
@@ -114,7 +128,9 @@ public class BillableServiceMapper {
         service.setServiceType(Context.getConceptService().getConceptByUuid(mapper.getServiceType()));
         service.setServiceCategory(Context.getConceptService().getConceptByUuid(mapper.getServiceCategory()));
         service.setServiceStatus(mapper.getServiceStatus());
-
+        if (StringUtils.isNotBlank(mapper.getStockItem())) {
+            service.setStockItem(Context.getService(StockManagementService.class).getStockItemByUuid(mapper.getStockItem()));
+        }
         // Pass the new prices from the mapper to syncCollection
         List<CashierItemPrice> updatedPrices = mapper.getServicePrices().stream().map(itemPrice -> {
             CashierItemPrice price = new CashierItemPrice();

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -866,4 +866,33 @@
 			<column name="date_created"/>
 		</createIndex>
 	</changeSet>
+
+	<changeSet id="openhmis.cashier-001-v3.0.0-202408291429" author="aojwang">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<columnExists tableName="cashier_billable_service" columnName="stock_item_id"/>
+			</not>
+		</preConditions>
+		<comment>Adding the column item_id to the table cashier_billable_service</comment>
+		<addColumn tableName="cashier_billable_service">
+			<column name="stock_item_id" type="int">
+				<constraints nullable="true"/>
+			</column>
+		</addColumn>
+
+		<addForeignKeyConstraint constraintName="cashier_billable_stock_item_id_fk"
+								 baseTableName="cashier_billable_service" baseColumnNames="stock_item_id"
+								 referencedTableName="stockmgmt_stock_item" referencedColumnNames="stock_item_id"
+								 onDelete="CASCADE" onUpdate="CASCADE"/>
+	</changeSet>
+
+	<changeSet id="openhmis.cashier-001-v3.0.0-202408291450" author="aojwang">
+		<preConditions onFail="MARK_RAN">
+			<columnExists tableName="cashier_item_price" columnName="item_id"/>
+		</preConditions>
+		<comment>Dropping the irrelevant column item_id</comment>
+		<dropForeignKeyConstraint baseTableName="cashier_item_price" constraintName="cashier_item_price_item_id_fk" />
+		<dropColumn tableName="cashier_item_price" columnName="item_id"/>
+	</changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
https://thepalladiumgroup.atlassian.net/browse/KHP3-6501

With this change, creating a billable for stock/commodity will require one to provide the stock item uuid. Other concept related details should be inferred from the stock item's concept. The _**stockItem**_ attribute holds the uuid of the stock item

`{
  "name":"Rifampicin2 (150mg)",
  "shortName":"Rifampicin2 (150mg)",
  "serviceType":"c9604249-db0a-4d03-b074-fc6bc2fa13e6",
  "stockItem":"238d2f2f-7a90-433c-a638-795d9e6dfc37",
  "servicePrices":[{
    "paymentMode":"beac329b-f1dc-4a33-9e7c-d95821a137a6",
    "price":"300",
    "name":"Insurance"}],
  "serviceStatus":"ENABLED",
  "concept":"767AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" 
}`

The stockItem attribute has also been added to the API response for billable services. You can use something like the below for a custom rep.
`openmrs/ws/rest/v1/cashier/billableService?v=custom:(uuid,name,shortName,serviceStatus,**stockItem**,serviceType:(uuid,display),servicePrices:(uuid,name,paymentMode,price),concept:(uuid,display))`

