### PR TITLE
fix check for unset exemptions config

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/exemptions/SampleBillingExemptionBuilder.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/exemptions/SampleBillingExemptionBuilder.java
@@ -13,6 +13,7 @@
  */
 package org.openmrs.module.kenyaemr.cashier.exemptions;
 
+import org.apache.commons.lang3.StringUtils;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.node.ArrayNode;
@@ -45,7 +46,7 @@ public class SampleBillingExemptionBuilder extends BillingExemptions {
         String exemptionConfig = adminService.getGlobalProperty("kenyaemr.billing.exemptions");
         ObjectNode config = null;
 
-        if (exemptionConfig != null) {
+        if (StringUtils.isNotBlank(exemptionConfig)) {
             ObjectMapper mapper = new ObjectMapper();
             try {
                 config = (ObjectNode) mapper.readTree(exemptionConfig);


### PR DESCRIPTION
Fix for the error below:

java.io.EOFException: No content to map to Object due to end of input
	at org.codehaus.jackson.map.ObjectMapper._initForReading(ObjectMapper.java:2775)
	at org.codehaus.jackson.map.ObjectMapper._readMapAndClose(ObjectMapper.java:2718)
	at org.codehaus.jackson.map.ObjectMapper.readTree(ObjectMapper.java:1542)