### PR TITLE
move timesheet resource to be served under v1 route

### DIFF
--- a/omod/src/main/java/org/openmrs/module/kenyaemr/cashier/rest/resource/TimesheetResource.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/cashier/rest/resource/TimesheetResource.java
@@ -30,7 +30,7 @@ import java.text.DateFormat;
 /**
  * REST resource representing a {@link Timesheet}.
  */
-@Resource(name = RestConstants.VERSION_2 + CashierResourceController.KENYAEMR_CASHIER_NAMESPACE + "/timesheet", supportedClass = Timesheet.class,
+@Resource(name = RestConstants.VERSION_1 + CashierResourceController.KENYAEMR_CASHIER_NAMESPACE + "/timesheet", supportedClass = Timesheet.class,
         supportedOpenmrsVersions = { "2.0 - 2.*" })
 public class TimesheetResource extends BaseRestDataResource<Timesheet> {
 	@Override


### PR DESCRIPTION
This moves the timesheet resource to be accessed under v1. This was originally accessed under v2 and wasn't available