### PR TITLE
(fix)  KHP3-7040 : Fix UnknownFormatConversionException in CashierRestController logging statement

### DIFF
--- a/omod/src/main/java/org/openmrs/module/kenyaemr/cashier/rest/controller/CashierRestController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/cashier/rest/controller/CashierRestController.java
@@ -19,14 +19,14 @@ public class CashierRestController extends BaseRestController {
     @RequestMapping(method = RequestMethod.POST, path = "/billable-service")
     @ResponseBody
     public Object get(@RequestBody BillableServiceMapper request) {
-        //if the request has a uuid, update the billable service item
+        // Update the associated billable service item if a UUID is present in the request.
         if (request.getUuid() != null) {
             System.out.println("Updating billable service item " + request.getName());
             BillableService billableService = request.billableServiceUpdateMapper(request);
             IBillableItemsService service = Context.getService(IBillableItemsService.class);
             service.save(billableService);
         } else {
-            System.out.printf("Saving a new service item " + request.getName());
+            System.out.println("Saving a new service item " + request.getName());
             BillableService billableService = request.billableServiceMapper(request);
             IBillableItemsService service = Context.getService(IBillableItemsService.class);
             service.save(billableService);


### PR DESCRIPTION
### Description
Fix UnknownFormatConversionException occurring in CashierRestController when saving new billable service items. The error was caused by incorrect usage of `printf()` with string concatenation. Changed to use println() instead for proper string output.

Changes:
- Replaced System.out.printf("Saving a new service item " + request.getName()) with System.out.println()

## Root cause:
The original code mixed string concatenation with printf(), which caused the formatter to misinterpret parts of the concatenated string as format specifiers.

## Screenshot
![Screenshot 2024-11-06 at 12 32 39](https://github.com/user-attachments/assets/bdbbdbd7-156f-40f1-a645-71c0ad90cf76)
