### PR TITLE
(fix) : Respect includeVoided flag when filtering bill line items

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/impl/BillServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/impl/BillServiceImpl.java
@@ -258,6 +258,8 @@ public class BillServiceImpl extends BaseEntityDataServiceImpl<Bill> implements 
 
 			index = bill.getLineItems().indexOf(null);
 		}
+		// We also want to remove voided line items
+		bill.getLineItems().removeIf(billLineItem -> billLineItem.getVoided());
 	}
 
 	@Override

--- a/omod/src/main/java/org/openmrs/module/kenyaemr/cashier/rest/resource/BillResource.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/cashier/rest/resource/BillResource.java
@@ -13,7 +13,6 @@
  */
 package org.openmrs.module.kenyaemr.cashier.rest.resource;
 
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.util.Strings;
 import org.openmrs.Patient;
@@ -50,12 +49,13 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * REST resource representing a {@link Bill}.
  */
-@Resource(name = RestConstants.VERSION_1 + CashierResourceController.KENYAEMR_CASHIER_NAMESPACE + "/bill", supportedClass = Bill.class,
-		supportedOpenmrsVersions = {"2.0 - 2.*"})
+@Resource(name = RestConstants.VERSION_1 + CashierResourceController.KENYAEMR_CASHIER_NAMESPACE
+		+ "/bill", supportedClass = Bill.class, supportedOpenmrsVersions = { "2.0 - 2.*" })
 public class BillResource extends BaseRestDataResource<Bill> {
 	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
@@ -66,7 +66,7 @@ public class BillResource extends BaseRestDataResource<Bill> {
 			description.addProperty("cashPoint", Representation.REF);
 			description.addProperty("cashier", Representation.REF);
 			description.addProperty("dateCreated");
-			description.addProperty("lineItems");
+			description.addProperty("lineItems", Representation.DEFAULT);
 			description.addProperty("patient", Representation.REF);
 			description.addProperty("payments", Representation.FULL);
 			description.addProperty("receiptNumber");
@@ -131,7 +131,7 @@ public class BillResource extends BaseRestDataResource<Bill> {
 
 	@Override
 	public Bill save(Bill bill) {
-		//TODO: Test all the ways that this could fail
+		// TODO: Test all the ways that this could fail
 
 		if (bill.getId() == null) {
 			if (bill.getCashier() == null) {
@@ -148,7 +148,8 @@ public class BillResource extends BaseRestDataResource<Bill> {
 				loadBillCashPoint(bill);
 			}
 
-			// Now that all all attributes have been set (i.e., payments and bill status) we can check to see if the bill
+			// Now that all all attributes have been set (i.e., payments and bill status) we
+			// can check to see if the bill
 			// is fully paid.
 			bill.synchronizeBillStatus();
 			if (bill.getStatus() == null) {
@@ -167,21 +168,46 @@ public class BillResource extends BaseRestDataResource<Bill> {
 		String createdOnOrBeforeDateStr = context.getRequest().getParameter("createdOnOrBefore");
 		String createdOnOrAfterDateStr = context.getRequest().getParameter("createdOnOrAfter");
 
-		Patient patient = Strings.isNotEmpty(patientUuid) ? Context.getPatientService().getPatientByUuid(patientUuid) : null;
+		// Add voided parameter with default false
+		String includedVoidedStr = context.getRequest().getParameter("includeVoided");
+		boolean includeVoided = Boolean.parseBoolean(includedVoidedStr);
+
+		Patient patient = Strings.isNotEmpty(patientUuid) ? Context.getPatientService().getPatientByUuid(patientUuid)
+				: null;
 		BillStatus billStatus = Strings.isNotEmpty(status) ? BillStatus.valueOf(status.toUpperCase()) : null;
-		CashPoint cashPoint = Strings.isNotEmpty(cashPointUuid) ? Context.getService(ICashPointService.class).getByUuid(cashPointUuid) : null;
-		Date createdOnOrBeforeDate = StringUtils.isNotBlank(createdOnOrBeforeDateStr) ?
-				(Date) ConversionUtil.convert(createdOnOrBeforeDateStr, Date.class) : null;
-		Date createdOnOrAfterDate = StringUtils.isNotBlank(createdOnOrAfterDateStr) ?
-				(Date) ConversionUtil.convert(createdOnOrAfterDateStr, Date.class) : null;
+		CashPoint cashPoint = Strings.isNotEmpty(cashPointUuid)
+				? Context.getService(ICashPointService.class).getByUuid(cashPointUuid)
+				: null;
+		Date createdOnOrBeforeDate = StringUtils.isNotBlank(createdOnOrBeforeDateStr)
+				? (Date) ConversionUtil.convert(createdOnOrBeforeDateStr, Date.class)
+				: null;
+		Date createdOnOrAfterDate = StringUtils.isNotBlank(createdOnOrAfterDateStr)
+				? (Date) ConversionUtil.convert(createdOnOrAfterDateStr, Date.class)
+				: null;
 
 		Bill searchTemplate = new Bill();
 		searchTemplate.setPatient(patient);
 		searchTemplate.setStatus(billStatus);
 		searchTemplate.setCashPoint(cashPoint);
+		searchTemplate.setVoided(!includeVoided);
 		IBillService service = Context.getService(IBillService.class);
 
-		List<Bill> result = service.getBills(new BillSearch(searchTemplate, createdOnOrAfterDate, createdOnOrBeforeDate, false));
+		List<Bill> result = service
+				.getBills(new BillSearch(searchTemplate, createdOnOrAfterDate, createdOnOrBeforeDate, includeVoided));
+
+		// Filter out voided line items if includeVoided is false
+		if (!includeVoided) {
+			for (Bill bill : result) {
+				if (bill.getLineItems() != null) {
+					List<BillLineItem> filteredItems = bill.getLineItems()
+							.stream()
+							.filter(item -> !item.getVoided())
+							.collect(Collectors.toList());
+					bill.setLineItems(new ArrayList<>(filteredItems));
+				}
+			}
+		}
+
 		return new AlreadyPaged<>(context, result, false);
 	}
 
@@ -217,8 +243,8 @@ public class BillResource extends BaseRestDataResource<Bill> {
 			AdministrationService adminService = Context.getAdministrationService();
 			boolean timesheetRequired;
 			try {
-				timesheetRequired =
-						Boolean.parseBoolean(adminService.getGlobalProperty(ModuleSettings.TIMESHEET_REQUIRED_PROPERTY));
+				timesheetRequired = Boolean
+						.parseBoolean(adminService.getGlobalProperty(ModuleSettings.TIMESHEET_REQUIRED_PROPERTY));
 			} catch (Exception e) {
 				timesheetRequired = false;
 			}


### PR DESCRIPTION
### Problem
When voiding line items in a bill, the `includeVoided=false` parameter is not filtering out voided line items and bills as expected.

### Solution
Implemented proper filtering logic to respect the `includeVoided` flag, ensuring voided items are excluded from results when the flag is set to false.

### Testing
- Verified voided line items are hidden when `includeVoided=false`
- Confirmed voided line items appear when `includeVoided=true`
- Tested with both single and multiple voided items