### PR TITLE
Exclude line items with pending payment status from the printed receipt

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/impl/BillServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/impl/BillServiceImpl.java
@@ -489,6 +489,9 @@ public class BillServiceImpl extends BaseEntityDataServiceImpl<Bill> implements 
 	}
 
 	private void addBillLineItem(BillLineItem item, Table table, PdfFont font) {
+		if (item.getPaymentStatus().equals(BillStatus.PENDING)) { // all other statuses mean that the line item's bill is settled
+			return;
+		}
 		String itemName = "";
 		if (item.getItem() != null) {
 			itemName = item.getItem().getCommonName();


### PR DESCRIPTION

This PR excludes line items with unsettled bills from a receipt printout. 
Ticket: [KHP3-7300](https://thepalladiumgroup.atlassian.net/browse/KHP3-7300)

[KHP3-7300]: https://thepalladiumgroup.atlassian.net/browse/KHP3-7300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ