### PR TITLE
(chore) : Update order-expansion module version and github workflow to publish

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,0 +1,57 @@
+name: Build and Publish to Nexus
+
+on:
+  # Manually triggered workflow using the "Run workflow" button
+  workflow_dispatch:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "8"
+
+      - name: Build with Maven
+        run: mvn -B package -DskipTests
+
+  publish:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "8"
+
+      - name: Set settings.xml
+        uses: s4u/maven-settings-action@v3.0.0
+        with:
+          servers: |
+            [{
+              "id": "mks-repo",
+              "username": "${{ secrets.MAVEN_USERNAME }}",
+              "password": "${{ secrets.MAVEN_TOKEN }}"
+            },
+            {
+              "id": "mks-repo-snapshots",
+              "username": "${{ secrets.MAVEN_USERNAME }}",
+              "password": "${{ secrets.MAVEN_TOKEN }}"
+            }]
+
+      - name: Publish
+        run: mvn --batch-mode clean deploy -DskipTests

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>orderexpansion-api</artifactId>
-				<version>1.0.0-SNAPSHOT</version>
+				<version>1.0.0</version>
 				<type>jar</type>
 				<scope>provided</scope>
 			</dependency>


### PR DESCRIPTION
### Description

Update this to use version `1.0.0` for order-expansion following this [PR](https://github.com/palladiumkenya/openmrs-module-orderexpansion/commit/58ae08eed0bce0b016c5eb2b4d66781c73f97e34) also added functionality to publish this module cc @makombe @corneliouzbett

@makombe we need to set the `MAVEN_USERNAME` and `MAVEN_TOKEN` to organization level to be reused across the different apps