### PR TITLE
fix : resolve deposit service bean creating error

### DIFF
--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -236,7 +236,7 @@
 		<property name="transactionManager" ref="transactionManager" />
 		<property name="target">
 			<bean class="org.openmrs.module.kenyaemr.cashier.api.impl.DepositServiceImpl">
-				<property name="repository" ref="depositEntityDataService" />
+				<property name="repository" ref="genericRepositoryDao" />
 			</bean>
 		</property>
 		<property name="preInterceptors" ref="serviceInterceptors" />


### PR DESCRIPTION
### Description

Fixes Spring bean creation error in deposit service by using the correct repository injection. The service was failing to start due to a type conversion issue between **IEntityDataService** and **BaseHibernateRepository**. 

cc @PatrickWaweru @patryllus @makombe please verify this is correct