### PR TITLE
refactor : use generic repository for deposit service

### DIFF
--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -256,23 +256,13 @@
 		<constructor-arg name="sessionFactory" ref="dbSessionFactory"/>
 	</bean>
 
-	<!-- Deposit Repository -->
-	<bean id="depositRepository" class="org.openmrs.module.kenyaemr.cashier.api.base.entity.db.hibernate.BaseHibernateRepositoryImpl">
-		<constructor-arg name="sessionFactory" ref="dbSessionFactory"/>
-	</bean>
-
 	<!-- Deposit Entity Data Service -->
 	<bean id="depositEntityDataService" class="org.openmrs.module.kenyaemr.cashier.api.impl.DepositEntityDataServiceImpl">
-		<property name="repository" ref="depositRepository"/>
-	</bean>
-
-	<!-- DepositTransaction Repository -->
-	<bean id="depositTransactionRepository" class="org.openmrs.module.kenyaemr.cashier.api.base.entity.db.hibernate.BaseHibernateRepositoryImpl">
-		<constructor-arg name="sessionFactory" ref="dbSessionFactory"/>
+		<property name="repository" ref="genericRepositoryDao"/>
 	</bean>
 
 	<!-- DepositTransaction Entity Data Service -->
 	<bean id="depositTransactionEntityDataService" class="org.openmrs.module.kenyaemr.cashier.api.impl.DepositTransactionEntityDataServiceImpl">
-		<property name="repository" ref="depositTransactionRepository"/>
+		<property name="repository" ref="genericRepositoryDao"/>
 	</bean>
 </beans>


### PR DESCRIPTION
## Description
This PR refactors the deposit service to use the generic repository approach, making it consistent with the bills service implementation. The change simplifies the dependency chain and reduces the number of repository instances while maintaining all existing functionality.

## Changes
- Removed specialized repository beans (`depositRepository` and `depositTransactionRepository`)
- Updated `depositEntityDataService` and `depositTransactionEntityDataService` to use `genericRepositoryDao`
- No changes required to implementation classes as they were already compatible with the generic repository approach