### PR TITLE
fix : resolve null pointer while filtering line items

### DIFF
--- a/omod/src/main/java/org/openmrs/module/kenyaemr/cashier/rest/resource/BillResource.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/cashier/rest/resource/BillResource.java
@@ -226,7 +226,7 @@ public class BillResource extends BaseRestDataResource<Bill> {
 				if (bill.getLineItems() != null) {
 					List<BillLineItem> filteredItems = bill.getLineItems()
 							.stream()
-							.filter(item -> !item.getVoided())
+							.filter(item -> item != null && !item.getVoided())
 							.collect(Collectors.toList());
 					bill.setLineItems(new ArrayList<>(filteredItems));
 				}
@@ -345,6 +345,10 @@ public class BillResource extends BaseRestDataResource<Bill> {
 
 	@PropertyGetter("balance")
 	public BigDecimal getBalance(Bill instance) {
+		if (instance.getLineItems() == null) {
+			return BigDecimal.ZERO;
+		}
+		
 		BigDecimal totalBillAmount = instance.getLineItems().stream()
 				.filter(item -> !item.getVoided() && 
 						(item.getPaymentStatus() == null || !item.getPaymentStatus().equals("EXEMPTED")))


### PR DESCRIPTION
### Description

This PR addresses critical null pointer exceptions that were occurring in the **BillResource** class when filtering bill line items and calculating bill balances. The fix ensures robust handling of null values in bill line item collections.