### PR TITLE
feat: add bill closure feature with manual close/reopen functionalities

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/IBillService.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/IBillService.java
@@ -140,4 +140,13 @@ public interface IBillService extends IEntityDataService<Bill> {
 	 * @return List of non-closed bills for the patient on the same day.
 	 */
 	List<Bill> searchBill(Patient patient);
+
+	/**
+	 * Searches for all bills (including closed ones) for a patient.
+	 * @param patient The patient to search for bills.
+	 * @return List of all bills for the patient, including closed ones.
+	 */
+	@Transactional(readOnly = true)
+	@Authorized({ PrivilegeConstants.VIEW_BILLS })
+	List<Bill> getAllBillsForPatient(Patient patient);
 }

--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/IBillService.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/IBillService.java
@@ -110,4 +110,34 @@ public interface IBillService extends IEntityDataService<Bill> {
 	@Transactional(readOnly = true)
 	@Authorized({ PrivilegeConstants.VIEW_BILLS })
 	File downloadBillReceipt(Bill bill);
+
+	/**
+	 * Closes a bill manually, preventing new items from being added.
+	 * @param bill The bill to close.
+	 * @param reason The reason for closing the bill.
+	 * @return The updated bill.
+	 * @should throw IllegalArgumentException if reason is null or empty
+	 * @should throw AccessControlException if user lacks CLOSE_BILLS privilege
+	 * @should close the bill and set close metadata
+	 */
+	@Authorized({ PrivilegeConstants.CLOSE_BILLS })
+	Bill closeBill(Bill bill, String reason);
+
+	/**
+	 * Reopens a closed bill, allowing new items to be added.
+	 * @param bill The bill to reopen.
+	 * @return The updated bill.
+	 * @should throw IllegalStateException if bill is not closed
+	 * @should throw AccessControlException if user lacks REOPEN_BILLS privilege
+	 * @should reopen the bill and clear close metadata
+	 */
+	@Authorized({ PrivilegeConstants.REOPEN_BILLS })
+	Bill reopenBill(Bill bill);
+
+	/**
+	 * Searches for non-closed bills for a patient created on the same day.
+	 * @param patient The patient to search for bills.
+	 * @return List of non-closed bills for the patient on the same day.
+	 */
+	List<Bill> searchBill(Patient patient);
 }

--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/model/BillLineItem.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/model/BillLineItem.java
@@ -53,9 +53,12 @@ public class BillLineItem extends BaseOpenmrsData {
 	/**
 	 * Get the total price for the line item
 	 *
-	 * @return double the total price for the line item
+	 * @return BigDecimal the total price for the line item, or BigDecimal.ZERO if price or quantity is null
 	 */
 	public BigDecimal getTotal() {
+		if (price == null || quantity == null) {
+			return BigDecimal.ZERO;
+		}
 		return price.multiply(BigDecimal.valueOf(quantity));
 	}
 

--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/model/BillStatus.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/model/BillStatus.java
@@ -14,7 +14,8 @@
 package org.openmrs.module.kenyaemr.cashier.api.model;
 
 /**
- * The allowable statuses that a {@link Bill} can have.
+ * The allowable payment statuses that a {@link Bill} can have.
+ * Note: Bill closure is handled by the 'closed' property, not by status.
  */
 public enum BillStatus {
 	PENDING(0), POSTED(4), PAID(1), CANCELLED(2), ADJUSTED(3), EXEMPTED(5), CREDITED(6);

--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/search/BillSearch.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/search/BillSearch.java
@@ -28,7 +28,7 @@ import java.util.Date;
 public class BillSearch extends BaseDataTemplateSearch<Bill> {
 	private Date createdOnOrBefore;
 	private Date createdOnOrAfter;
-	private Boolean includeClosedBills = false;
+	private Boolean includeClosedBills = true; // Changed default to true to show all bills by default
 
 	public BillSearch() {
 		this(new Bill(), false);
@@ -53,7 +53,7 @@ public class BillSearch extends BaseDataTemplateSearch<Bill> {
 		super(template, includeRetired);
 		this.createdOnOrAfter = createdOnOrAfter;
 		this.createdOnOrBefore = createdOnOrBefore;
-		this.includeClosedBills = includeClosedBills != null ? includeClosedBills : false;
+		this.includeClosedBills = includeClosedBills != null ? includeClosedBills : true; // Changed default to true
 	}
 
 	@Override
@@ -74,10 +74,12 @@ public class BillSearch extends BaseDataTemplateSearch<Bill> {
 			criteria.add(Restrictions.eq("status", bill.getStatus()));
 		}
 
-		// Exclude closed bills by default unless explicitly requested
+		// Include all bills by default unless explicitly requested to exclude closed bills
 		// Use only the 'closed' property to identify closed bills, not BillStatus
+		// Also treat voided bills as closed bills
 		if (!includeClosedBills) {
 			criteria.add(Restrictions.eq("closed", false));
+			criteria.add(Restrictions.eq("voided", false));
 		}
 
 		if (getCreatedOnOrBefore() != null) {
@@ -115,6 +117,6 @@ public class BillSearch extends BaseDataTemplateSearch<Bill> {
 	}
 
 	public void setIncludeClosedBills(Boolean includeClosedBills) {
-		this.includeClosedBills = includeClosedBills != null ? includeClosedBills : false;
+		this.includeClosedBills = includeClosedBills != null ? includeClosedBills : true; // Changed default to true
 	}
 }

--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/search/BillSearch.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/search/BillSearch.java
@@ -14,7 +14,6 @@
 package org.openmrs.module.kenyaemr.cashier.api.search;
 
 import org.hibernate.Criteria;
-import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Restrictions;
 import org.openmrs.module.kenyaemr.cashier.api.base.entity.search.BaseDataTemplateSearch;
 import org.openmrs.module.kenyaemr.cashier.api.model.Bill;
@@ -29,6 +28,8 @@ import java.util.Date;
 public class BillSearch extends BaseDataTemplateSearch<Bill> {
 	private Date createdOnOrBefore;
 	private Date createdOnOrAfter;
+	private Boolean includeClosedBills = false;
+
 	public BillSearch() {
 		this(new Bill(), false);
 	}
@@ -47,6 +48,14 @@ public class BillSearch extends BaseDataTemplateSearch<Bill> {
 		this.createdOnOrBefore = createdOnOrBefore;
 	}
 
+	public BillSearch(Bill template, Date createdOnOrAfter, Date createdOnOrBefore, Boolean includeRetired,
+			Boolean includeClosedBills) {
+		super(template, includeRetired);
+		this.createdOnOrAfter = createdOnOrAfter;
+		this.createdOnOrBefore = createdOnOrBefore;
+		this.includeClosedBills = includeClosedBills != null ? includeClosedBills : false;
+	}
+
 	@Override
 	public void updateCriteria(Criteria criteria) {
 		super.updateCriteria(criteria);
@@ -63,6 +72,12 @@ public class BillSearch extends BaseDataTemplateSearch<Bill> {
 		}
 		if (bill.getStatus() != null) {
 			criteria.add(Restrictions.eq("status", bill.getStatus()));
+		}
+
+		// Exclude closed bills by default unless explicitly requested
+		// Use only the 'closed' property to identify closed bills, not BillStatus
+		if (!includeClosedBills) {
+			criteria.add(Restrictions.eq("closed", false));
 		}
 
 		if (getCreatedOnOrBefore() != null) {
@@ -93,5 +108,13 @@ public class BillSearch extends BaseDataTemplateSearch<Bill> {
 
 	public void setCreatedOnOrAfter(Date createdOnOrAfter) {
 		this.createdOnOrAfter = createdOnOrAfter;
+	}
+
+	public Boolean getIncludeClosedBills() {
+		return includeClosedBills;
+	}
+
+	public void setIncludeClosedBills(Boolean includeClosedBills) {
+		this.includeClosedBills = includeClosedBills != null ? includeClosedBills : false;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/util/PrivilegeConstants.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/util/PrivilegeConstants.java
@@ -34,6 +34,8 @@ public class PrivilegeConstants {
 	public static final String ADJUST_BILLS = "Adjust Cashier Bills";
 	public static final String VIEW_BILLS = "View Cashier Bills";
 	public static final String PURGE_BILLS = "Purge Cashier Bills";
+	public static final String CLOSE_BILLS = "Close Cashier Bills";
+	public static final String REOPEN_BILLS = "Reopen Cashier Bills";
 
 	public static final String REFUND_MONEY = "Refund Money";
 	public static final String REPRINT_RECEIPT = "Reprint Receipt";
@@ -61,7 +63,7 @@ public class PrivilegeConstants {
 	public static final String PURGE_DEPOSITS = "Purge Deposits";
 
 	public static final String[] PRIVILEGE_NAMES = new String[] { MANAGE_BILLS, ADJUST_BILLS, VIEW_BILLS, PURGE_BILLS,
-	        REFUND_MONEY, REPRINT_RECEIPT, MANAGE_TIMESHEETS, VIEW_TIMESHEETS, PURGE_TIMESHEETS, MANAGE_METADATA,
+	        CLOSE_BILLS, REOPEN_BILLS, REFUND_MONEY, REPRINT_RECEIPT, MANAGE_TIMESHEETS, VIEW_TIMESHEETS, PURGE_TIMESHEETS, MANAGE_METADATA,
 	        VIEW_METADATA, PURGE_METADATA, APP_VIEW_CASHIER_APP, TASK_CREATE_NEW_BILL_PAGE, TASK_ADJUST_CASHIER_BILL,
 	        TASK_CASHIER_TIMESHEETS_PAGE, TASK_MANAGE_CASHIER_MODULE_PAGE, TASK_MANAGE_CASHIER_METADATA,
 	        TASK_CASHIER_TIMESHEETS_PAGE, TASK_MANAGE_CASHIER_MODULE_PAGE, TASK_VIEW_CASHIER_REPORTS,

--- a/api/src/main/resources/Bill.hbm.xml
+++ b/api/src/main/resources/Bill.hbm.xml
@@ -99,6 +99,11 @@
 			</type>
 		</property>
 
+		<property name="closed" type="java.lang.Boolean" column="closed" length="1" not-null="true" />
+		<property name="closeReason" type="java.lang.String" column="close_reason" length="255" />
+		<many-to-one name="closedBy" class="org.openmrs.User" column="closed_by" />
+		<property name="dateClosed" type="java.util.Date" column="date_closed" length="19" />
+
 		<list name="lineItems" lazy="false" inverse="true" cascade="all-delete-orphan">
 			<key column="bill_id" />
 			<list-index column="line_item_order" />

--- a/api/src/test/java/org/openmrs/module/kenyaemr/cashier/api/impl/BillServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/kenyaemr/cashier/api/impl/BillServiceImplTest.java
@@ -1,121 +1,101 @@
-///*
-// * The contents of this file are subject to the OpenMRS Public License
-// * Version 1.1 (the "License"); you may not use this file except in
-// * compliance with the License. You may obtain a copy of the License at
-// * http://license.openmrs.org
-// *
-// * Software distributed under the License is distributed on an "AS IS"
-// * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
-// * License for the specific language governing rights and limitations
-// * under the License.
-// *
-// * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
-// */
-//package org.openmrs.module.kenyaemr.cashier.api.impl;
-//
-//import static org.mockito.Mockito.times;
-//import static org.mockito.Mockito.verify;
-//import static org.powermock.api.mockito.PowerMockito.mock;
-//import static org.powermock.api.mockito.PowerMockito.mockStatic;
-//import static org.powermock.api.mockito.PowerMockito.when;
-//
-//import org.junit.*;
-//import org.junit.Before;
-//import org.junit.BeforeClass;
-//import org.junit.Rule;
-//import org.junit.Test;
-//import org.openmrs.api.APIException;
-//import org.openmrs.api.context.Context;
-//import org.openmrs.module.kenyaemr.cashier.api.IBillService;
-//import org.openmrs.module.kenyaemr.cashier.api.IBillServiceTest;
-//import org.openmrs.module.kenyaemr.cashier.api.IReceiptNumberGenerator;
-//import org.openmrs.module.kenyaemr.cashier.api.ReceiptNumberGeneratorFactory;
-//import org.openmrs.module.kenyaemr.cashier.api.model.Bill;
-//import org.powermock.core.classloader.annotations.PrepareForTest;
-//import org.powermock.modules.agent.PowerMockAgent;
-//import org.powermock.modules.junit4.rule.PowerMockRule;
-//
-//@PrepareForTest(ReceiptNumberGeneratorFactory.class)
-//public class BillServiceImplTest extends IBillServiceTest {
-//	@Rule
-//	public PowerMockRule rule = new PowerMockRule();
-//
-//	@BeforeClass
-//	public static void beforeClass() throws Exception {
-//		PowerMockAgent.initializeIfNeeded();
-//	}
-//
-//	IReceiptNumberGenerator receiptNumberGenerator;
-//
-//	@Before
-//	public void before() throws Exception {
-//		super.before();
-//
-//		mockStatic(ReceiptNumberGeneratorFactory.class);
-//		receiptNumberGenerator = mock(IReceiptNumberGenerator.class);
-//
-//		when(ReceiptNumberGeneratorFactory.getGenerator())
-//		        .thenReturn(receiptNumberGenerator);
-//	}
-//
-//	@Override
-//	protected IBillService createService() {
-//		return Context.getService(IBillService.class);
-//	}
-//
-//	/**
-//	 * @verifies Generate a new receipt number if one has not been defined.
-//	 * @see BillServiceImpl#save(Bill)
-//	 */
-//	@Test
-//	public void save_shouldGenerateANewReceiptNumberIfOneHasNotBeenDefined() throws Exception {
-//		Bill bill = createEntity(true);
-//		bill.setReceiptNumber(null);
-//
-//		String receiptNumber = "Test Number";
-//		when(receiptNumberGenerator.generateNumber(bill))
-//		        .thenReturn(receiptNumber);
-//
-//		service.save(bill);
-//		Context.flushSession();
-//
-//		Bill savedBill = service.getById(bill.getId());
-//		Assert.assertEquals(receiptNumber, savedBill.getReceiptNumber());
-//
-//		verify(receiptNumberGenerator, times(1)).generateNumber(bill);
-//	}
-//
-//	/**
-//	 * @verifies Not generate a receipt number if one has already been defined.
-//	 * @see BillServiceImpl#save(Bill)
-//	 */
-//	@Test
-//	public void save_shouldNotGenerateAReceiptNumberIfOneHasAlreadyBeenDefined() throws Exception {
-//		String receiptNumber = "Test Number";
-//		Bill bill = createEntity(true);
-//		bill.setReceiptNumber(receiptNumber);
-//
-//		service.save(bill);
-//		Context.flushSession();
-//
-//		Bill savedBill = service.getById(bill.getId());
-//		Assert.assertEquals(receiptNumber, savedBill.getReceiptNumber());
-//
-//		verify(receiptNumberGenerator, times(0)).generateNumber(bill);
-//	}
-//
-//	/**
-//	 * @verifies Throw APIException if receipt number cannot be generated.
-//	 * @see BillServiceImpl#save(Bill)
-//	 */
-//	@Test(expected = APIException.class)
-//	public void save_shouldThrowAPIExceptionIfReceiptNumberCannotBeGenerated() throws Exception {
-//		Bill bill = createEntity(true);
-//		bill.setReceiptNumber(null);
-//
-//		when(receiptNumberGenerator.generateNumber(bill))
-//		        .thenThrow(new APIException("Test exception"));
-//
-//		service.save(bill);
-//	}
-//}
+/*
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.1 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.kenyaemr.cashier.api.impl;
+
+import org.junit.Test;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.kenyaemr.cashier.api.IBillService;
+import org.openmrs.module.kenyaemr.cashier.api.model.Bill;
+import org.openmrs.module.kenyaemr.cashier.api.model.BillStatus;
+import org.openmrs.Patient;
+import org.openmrs.Provider;
+import org.openmrs.module.kenyaemr.cashier.api.model.CashPoint;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for BillServiceImpl to ensure voided bills are treated as closed bills
+ */
+public class BillServiceImplTest extends BaseModuleContextSensitiveTest {
+
+    @Autowired
+    private IBillService billService;
+
+    /**
+     * @verifies Treat voided bills as closed bills in canAcceptNewItems method
+     * @see Bill#canAcceptNewItems()
+     */
+    @Test
+    public void canAcceptNewItems_shouldReturnFalseForVoidedBills() throws Exception {
+        // Create a bill and set it as voided
+        Bill voidedBill = new Bill();
+        voidedBill.setVoided(true);
+        voidedBill.setVoidReason("Test void reason");
+
+        // Verify that voided bills cannot accept new items
+        assertFalse("Voided bills should not be able to accept new items", voidedBill.canAcceptNewItems());
+    }
+
+    /**
+     * @verifies Return false for closed bills in canAcceptNewItems method
+     * @see Bill#canAcceptNewItems()
+     */
+    @Test
+    public void canAcceptNewItems_shouldReturnFalseForClosedBills() throws Exception {
+        // Create a bill and set it as closed
+        Bill closedBill = new Bill();
+        closedBill.setClosed(true);
+        closedBill.setCloseReason("Test close reason");
+
+        // Verify that closed bills cannot accept new items
+        assertFalse("Closed bills should not be able to accept new items", closedBill.canAcceptNewItems());
+    }
+
+    /**
+     * @verifies Return true for active bills in canAcceptNewItems method
+     * @see Bill#canAcceptNewItems()
+     */
+    @Test
+    public void canAcceptNewItems_shouldReturnTrueForActiveBills() throws Exception {
+        // Create a bill that is neither closed nor voided
+        Bill activeBill = new Bill();
+        activeBill.setClosed(false);
+        activeBill.setVoided(false);
+
+        // Verify that active bills can accept new items
+        assertTrue("Active bills should be able to accept new items", activeBill.canAcceptNewItems());
+    }
+
+    /**
+     * @verifies Return false for bills that are both closed and voided
+     * @see Bill#canAcceptNewItems()
+     */
+    @Test
+    public void canAcceptNewItems_shouldReturnFalseForClosedAndVoidedBills() throws Exception {
+        // Create a bill that is both closed and voided
+        Bill closedAndVoidedBill = new Bill();
+        closedAndVoidedBill.setClosed(true);
+        closedAndVoidedBill.setCloseReason("Test close reason");
+        closedAndVoidedBill.setVoided(true);
+        closedAndVoidedBill.setVoidReason("Test void reason");
+
+        // Verify that bills that are both closed and voided cannot accept new items
+        assertFalse("Bills that are both closed and voided should not be able to accept new items", 
+                   closedAndVoidedBill.canAcceptNewItems());
+    }
+}

--- a/omod/src/main/java/org/openmrs/module/kenyaemr/cashier/web/controller/BillActionController.java
+++ b/omod/src/main/java/org/openmrs/module/kenyaemr/cashier/web/controller/BillActionController.java
@@ -1,0 +1,144 @@
+/*
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.1 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.kenyaemr.cashier.web.controller;
+
+import org.openmrs.api.context.Context;
+import org.openmrs.module.kenyaemr.cashier.api.IBillService;
+import org.openmrs.module.kenyaemr.cashier.api.model.Bill;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.v1_0.controller.BaseRestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * REST controller for bill actions like close and reopen.
+ * This controller provides action endpoints for bill operations.
+ * 
+ * Endpoints:
+ * - POST /rest/v1/kenyaemr-cashier/bill/{billUuid}/close
+ * - POST /rest/v1/kenyaemr-cashier/bill/{billUuid}/reopen
+ */
+@Controller
+@RequestMapping(value = "/rest/" + RestConstants.VERSION_1 + "/kenyaemr-cashier/bill")
+public class BillActionController extends BaseRestController {
+
+    /**
+     * Closes a bill manually, preventing new items from being added.
+     * 
+     * @param billUuid The UUID of the bill to close
+     * @param requestBody The request body containing the close reason
+     * @return The updated bill information
+     */
+    @RequestMapping(value = "/{billUuid}/close", method = RequestMethod.POST)
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> closeBill(
+            @PathVariable("billUuid") String billUuid,
+            @RequestBody Map<String, Object> requestBody) {
+        
+        try {
+            String reason = (String) requestBody.get("reason");
+            
+            if (reason == null || reason.trim().isEmpty()) {
+                Map<String, Object> error = new HashMap<>();
+                error.put("error", "Close reason is required");
+                return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+            }
+            
+            IBillService service = Context.getService(IBillService.class);
+            Bill bill = service.getByUuid(billUuid);
+            
+            if (bill == null) {
+                Map<String, Object> error = new HashMap<>();
+                error.put("error", "Bill not found with UUID: " + billUuid);
+                return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+            }
+            
+            Bill closedBill = service.closeBill(bill, reason);
+            
+            Map<String, Object> response = new HashMap<>();
+            response.put("uuid", closedBill.getUuid());
+            response.put("receiptNumber", closedBill.getReceiptNumber());
+            response.put("status", closedBill.getStatus());
+            response.put("closed", closedBill.isClosed());
+            response.put("closeReason", closedBill.getCloseReason());
+            response.put("closedBy", closedBill.getClosedBy() != null ? closedBill.getClosedBy().getUuid() : null);
+            response.put("dateClosed", closedBill.getDateClosed());
+            response.put("balance", closedBill.getBalance());
+            response.put("message", "Bill closed successfully");
+            
+            return new ResponseEntity<>(response, HttpStatus.OK);
+            
+        } catch (IllegalStateException e) {
+            Map<String, Object> error = new HashMap<>();
+            error.put("error", e.getMessage());
+            return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+        } catch (Exception e) {
+            Map<String, Object> error = new HashMap<>();
+            error.put("error", "An error occurred while closing the bill: " + e.getMessage());
+            return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Reopens a closed bill, allowing new items to be added.
+     * 
+     * @param billUuid The UUID of the bill to reopen
+     * @return The updated bill information
+     */
+    @RequestMapping(value = "/{billUuid}/reopen", method = RequestMethod.POST)
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> reopenBill(
+            @PathVariable("billUuid") String billUuid) {
+        
+        try {
+            IBillService service = Context.getService(IBillService.class);
+            Bill bill = service.getByUuid(billUuid);
+            
+            if (bill == null) {
+                Map<String, Object> error = new HashMap<>();
+                error.put("error", "Bill not found with UUID: " + billUuid);
+                return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+            }
+            
+            Bill reopenedBill = service.reopenBill(bill);
+            
+            Map<String, Object> response = new HashMap<>();
+            response.put("uuid", reopenedBill.getUuid());
+            response.put("receiptNumber", reopenedBill.getReceiptNumber());
+            response.put("status", reopenedBill.getStatus());
+            response.put("closed", reopenedBill.isClosed());
+            response.put("closeReason", reopenedBill.getCloseReason());
+            response.put("closedBy", reopenedBill.getClosedBy() != null ? reopenedBill.getClosedBy().getUuid() : null);
+            response.put("dateClosed", reopenedBill.getDateClosed());
+            response.put("balance", reopenedBill.getBalance());
+            response.put("message", "Bill reopened successfully");
+            
+            return new ResponseEntity<>(response, HttpStatus.OK);
+            
+        } catch (IllegalStateException e) {
+            Map<String, Object> error = new HashMap<>();
+            error.put("error", e.getMessage());
+            return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+        } catch (Exception e) {
+            Map<String, Object> error = new HashMap<>();
+            error.put("error", "An error occurred while reopening the bill: " + e.getMessage());
+            return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+} 

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -218,6 +218,16 @@
 		<description>Able to purge bills</description>
 	</privilege>
 
+	<privilege>
+		<name>Close Cashier Bills</name>
+		<description>Able to manually close bills to prevent new items from being added</description>
+	</privilege>
+
+	<privilege>
+		<name>Reopen Cashier Bills</name>
+		<description>Able to reopen closed bills to allow new items to be added</description>
+	</privilege>
+
 	<!--  Metadata  -->
 	<privilege>
 		<name>View Cashier Metadata</name>

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -1008,51 +1008,69 @@
 	<changeSet id="kenyaemr.cashier-20240507-1" author="Donald Kibet">
 		<preConditions onFail="MARK_RAN">
 			<not>
-				<columnExists tableName="cashier_deposit_transaction" columnName="bill_line_item_id"/>
+				<columnExists tableName="cashier_deposit_transaction" columnName="bill_line_item_id" />
 			</not>
 		</preConditions>
-		
+
 		<addColumn tableName="cashier_deposit_transaction">
 			<column name="bill_line_item_id" type="int">
-				<constraints nullable="true" foreignKeyName="fk_deposit_transaction_bill_line_item" 
-							references="cashier_bill_line_item(bill_line_item_id)"/>
+				<constraints nullable="true" foreignKeyName="fk_deposit_transaction_bill_line_item"
+					references="cashier_bill_line_item(bill_line_item_id)" />
 			</column>
 		</addColumn>
-		
-		<createIndex tableName="cashier_deposit_transaction" indexName="idx_deposit_transaction_bill_line_item">
-			<column name="bill_line_item_id"/>
+
+		<createIndex tableName="cashier_deposit_transaction"
+			indexName="idx_deposit_transaction_bill_line_item">
+			<column name="bill_line_item_id" />
 		</createIndex>
 	</changeSet>
 
-	<changeSet id="kenyaemr.cashier-001-add-bill-closure-feature" author="kenyaemr-cashier">
-		<comment>Add bill closure feature to prevent new items from being added to closed bills</comment>
+	<changeSet id="kenyaemr.cashier-001-add-bill-closure-feature" author="Donald Kibet">
+		<preConditions onError="WARN" onFail="MARK_RAN">
+			<tableExists tableName="cashier_bill" />
+			<not>
+				<columnExists columnName="closed" tableName="cashier_bill" />
+			</not>
+			<not>
+				<columnExists columnName="close_reason" tableName="cashier_bill" />
+			</not>
+			<not>
+				<columnExists columnName="closed_by" tableName="cashier_bill" />
+			</not>
+			<not>
+				<columnExists columnName="date_closed" tableName="cashier_bill" />
+			</not>
+		</preConditions>
 		
+		<comment>Add bill closure feature to prevent new items from being added to closed bills</comment>
+
 		<!-- Add new columns to cashier_bill table -->
 		<addColumn tableName="cashier_bill">
 			<column name="closed" type="boolean" defaultValueBoolean="false">
 				<constraints nullable="false" />
 			</column>
 		</addColumn>
-		
+
 		<addColumn tableName="cashier_bill">
 			<column name="close_reason" type="varchar(255)" />
 		</addColumn>
-		
+
 		<addColumn tableName="cashier_bill">
 			<column name="closed_by" type="int" />
 		</addColumn>
-		
+
 		<addColumn tableName="cashier_bill">
 			<column name="date_closed" type="datetime" />
 		</addColumn>
-		
+
 		<!-- Add foreign key constraint for closed_by -->
-		<addForeignKeyConstraint 
-			baseTableName="cashier_bill" 
-			baseColumnNames="closed_by" 
-			constraintName="fk_cashier_bill_closed_by" 
-			referencedTableName="users" 
+		<addForeignKeyConstraint
+			baseTableName="cashier_bill"
+			baseColumnNames="closed_by"
+			constraintName="fk_cashier_bill_closed_by"
+			referencedTableName="users"
 			referencedColumnNames="user_id" />
+			
 	</changeSet>
 
 </databaseChangeLog>

--- a/omod/src/main/resources/liquibase.xml
+++ b/omod/src/main/resources/liquibase.xml
@@ -1024,4 +1024,35 @@
 		</createIndex>
 	</changeSet>
 
+	<changeSet id="kenyaemr.cashier-001-add-bill-closure-feature" author="kenyaemr-cashier">
+		<comment>Add bill closure feature to prevent new items from being added to closed bills</comment>
+		
+		<!-- Add new columns to cashier_bill table -->
+		<addColumn tableName="cashier_bill">
+			<column name="closed" type="boolean" defaultValueBoolean="false">
+				<constraints nullable="false" />
+			</column>
+		</addColumn>
+		
+		<addColumn tableName="cashier_bill">
+			<column name="close_reason" type="varchar(255)" />
+		</addColumn>
+		
+		<addColumn tableName="cashier_bill">
+			<column name="closed_by" type="int" />
+		</addColumn>
+		
+		<addColumn tableName="cashier_bill">
+			<column name="date_closed" type="datetime" />
+		</addColumn>
+		
+		<!-- Add foreign key constraint for closed_by -->
+		<addForeignKeyConstraint 
+			baseTableName="cashier_bill" 
+			baseColumnNames="closed_by" 
+			constraintName="fk_cashier_bill_closed_by" 
+			referencedTableName="users" 
+			referencedColumnNames="user_id" />
+	</changeSet>
+
 </databaseChangeLog>

--- a/omod/src/main/resources/org/openmrs/module/kenyaemr/cashier/api/model/Bill.hbm.xml
+++ b/omod/src/main/resources/org/openmrs/module/kenyaemr/cashier/api/model/Bill.hbm.xml
@@ -99,6 +99,11 @@
 			</type>
 		</property>
 
+		<property name="closed" type="java.lang.Boolean" column="closed" length="1" not-null="true" />
+		<property name="closeReason" type="java.lang.String" column="close_reason" length="255" />
+		<many-to-one name="closedBy" class="org.openmrs.User" column="closed_by" />
+		<property name="dateClosed" type="java.util.Date" column="date_closed" length="19" />
+
 		<list name="lineItems" lazy="false" inverse="true" cascade="all-delete-orphan">
 			<key column="bill_id" />
 			<list-index column="line_item_order" />


### PR DESCRIPTION
### Description

Adds ability to close/reopen bills to prevent new items being added. Includes database fields for closure tracking (status, reason, user, date), new service methods, user privileges, REST endpoints, and audit trail. Closed bills are excluded from new bill generation and searches.

**Purpose**: Prevent accidental modifications to finalized bills while maintaining accountability and also prevent duplicated bills for the same patient during the same hospital visit.