### PR TITLE
fix : KHP3-6991 Resolve spring bean creation issue on Java8

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/impl/DepositTransactionServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/impl/DepositTransactionServiceImpl.java
@@ -3,11 +3,10 @@ package org.openmrs.module.kenyaemr.cashier.api.impl;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.OpenmrsObject;
-import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.kenyaemr.cashier.api.IDepositTransactionService;
 import org.openmrs.module.kenyaemr.cashier.api.base.PagingInfo;
-import org.openmrs.module.kenyaemr.cashier.api.base.entity.IEntityDataService;
-import org.openmrs.module.kenyaemr.cashier.api.base.entity.db.hibernate.BaseHibernateRepository;
+import org.openmrs.module.kenyaemr.cashier.api.base.entity.impl.BaseEntityDataServiceImpl;
+import org.openmrs.module.kenyaemr.cashier.api.base.entity.security.IEntityAuthorizationPrivileges;
 import org.openmrs.module.kenyaemr.cashier.api.model.DepositTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,64 +14,42 @@ import java.util.Collection;
 import java.util.List;
 
 @Transactional
-public class DepositTransactionServiceImpl extends BaseOpenmrsService implements IDepositTransactionService {
+public class DepositTransactionServiceImpl extends BaseEntityDataServiceImpl<DepositTransaction> implements IEntityAuthorizationPrivileges, IDepositTransactionService {
     private static final Log LOG = LogFactory.getLog(DepositTransactionServiceImpl.class);
 
-    private IEntityDataService<DepositTransaction> repository;
-
-    public void setRepository(IEntityDataService<DepositTransaction> repository) {
-        this.repository = repository;
+    @Override
+    protected IEntityAuthorizationPrivileges getPrivileges() {
+        return this;
     }
 
     @Override
-    public void setRepository(BaseHibernateRepository repository) {
-        this.repository.setRepository(repository);
+    protected void validate(DepositTransaction object) {
+        // No additional validation needed
     }
 
     @Override
-    @Transactional(readOnly = true)
-    public List<DepositTransaction> getAll() {
-        return repository.getAll();
+    protected Collection<? extends OpenmrsObject> getRelatedObjects(DepositTransaction entity) {
+        return null; // No related objects for deposit transactions
     }
 
     @Override
-    @Transactional(readOnly = true)
-    public List<DepositTransaction> getAll(PagingInfo paging) {
-        return repository.getAll(paging);
+    public String getVoidPrivilege() {
+        return null;
     }
 
     @Override
-    @Transactional(readOnly = true)
-    public List<DepositTransaction> getAll(boolean includeVoided) {
-        return repository.getAll(includeVoided);
+    public String getSavePrivilege() {
+        return null;
     }
 
     @Override
-    @Transactional(readOnly = true)
-    public List<DepositTransaction> getAll(Boolean includeVoided) {
-        return repository.getAll(includeVoided);
+    public String getPurgePrivilege() {
+        return null;
     }
 
     @Override
-    @Transactional(readOnly = true)
-    public List<DepositTransaction> getAll(boolean includeVoided, PagingInfo paging) {
-        return repository.getAll(includeVoided, paging);
-    }
-
-    @Override
-    @Transactional
-    public DepositTransaction save(DepositTransaction depositTransaction) {
-        if (depositTransaction == null) {
-            throw new NullPointerException("The deposit transaction to save must be defined.");
-        }
-
-        return repository.save(depositTransaction);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public DepositTransaction getById(int id) {
-        return repository.getById(id);
+    public String getGetPrivilege() {
+        return null;
     }
 
     @Override
@@ -81,51 +58,12 @@ public class DepositTransactionServiceImpl extends BaseOpenmrsService implements
         if (depositTransactionId == null) {
             throw new NullPointerException("The deposit transaction id must be defined.");
         }
-
-        return repository.getById(depositTransactionId);
+        return getById(depositTransactionId.intValue());
     }
 
     @Override
     @Transactional(readOnly = true)
-    public DepositTransaction getByUuid(String uuid) {
-        if (uuid == null) {
-            throw new NullPointerException("The deposit transaction uuid must be defined.");
-        }
-
-        return repository.getByUuid(uuid);
-    }
-
-    @Override
-    @Transactional
-    public void purge(DepositTransaction depositTransaction) {
-        if (depositTransaction == null) {
-            throw new NullPointerException("The deposit transaction to purge must be defined.");
-        }
-
-        repository.purge(depositTransaction);
-    }
-
-    @Override
-    @Transactional
-    public DepositTransaction voidEntity(DepositTransaction entity, String reason) {
-        return repository.voidEntity(entity, reason);
-    }
-
-    @Override
-    @Transactional
-    public DepositTransaction unvoidEntity(DepositTransaction entity) {
-        return repository.unvoidEntity(entity);
-    }
-
-    @Override
-    @Transactional
-    public DepositTransaction saveAll(DepositTransaction object, Collection<? extends OpenmrsObject> related) {
-        return repository.saveAll(object, related);
-    }
-
-    @Override
-    @Transactional
-    public void saveAll(Collection<? extends OpenmrsObject> collection) {
-        repository.saveAll(collection);
+    public List<DepositTransaction> getAll(Boolean includeVoided) {
+        return getAll(includeVoided != null ? includeVoided : false);
     }
 } 

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -236,7 +236,7 @@
 		<property name="transactionManager" ref="transactionManager" />
 		<property name="target">
 			<bean class="org.openmrs.module.kenyaemr.cashier.api.impl.DepositServiceImpl">
-				<property name="repository" ref="depositEntityDataService" />
+				<property name="repository" ref="genericRepositoryDao" />
 			</bean>
 		</property>
 		<property name="preInterceptors" ref="serviceInterceptors" />
@@ -246,7 +246,7 @@
 		<property name="transactionManager" ref="transactionManager" />
 		<property name="target">
 			<bean class="org.openmrs.module.kenyaemr.cashier.api.impl.DepositTransactionServiceImpl">
-				<property name="repository" ref="depositTransactionEntityDataService" />
+				<property name="repository" ref="genericRepositoryDao" />
 			</bean>
 		</property>
 		<property name="preInterceptors" ref="serviceInterceptors" />
@@ -254,15 +254,5 @@
 	</bean>
 	<bean id="genericRepositoryDao" class="org.openmrs.module.kenyaemr.cashier.api.base.entity.db.hibernate.BaseHibernateRepositoryImpl">
 		<constructor-arg name="sessionFactory" ref="dbSessionFactory"/>
-	</bean>
-
-	<!-- Deposit Entity Data Service -->
-	<bean id="depositEntityDataService" class="org.openmrs.module.kenyaemr.cashier.api.impl.DepositEntityDataServiceImpl">
-		<property name="repository" ref="genericRepositoryDao"/>
-	</bean>
-
-	<!-- DepositTransaction Entity Data Service -->
-	<bean id="depositTransactionEntityDataService" class="org.openmrs.module.kenyaemr.cashier.api.impl.DepositTransactionEntityDataServiceImpl">
-		<property name="repository" ref="genericRepositoryDao"/>
 	</bean>
 </beans>


### PR DESCRIPTION
## Root Cause

The issue was caused by **conflicting setter methods** in `DepositServiceImpl` and `DepositTransactionServiceImpl`:

### Method Signature Conflict
Both services had two different `setRepository` methods:
- `setRepository(IEntityDataService<Deposit> repository)` - Used by Spring configuration
- `setRepository(BaseHibernateRepository repository)` - Required by interface inheritance

### Spring Proxy Conversion Issue
In Java 8, Spring's type conversion is more strict. When Spring tried to inject the `depositEntityDataService` (a Spring proxy implementing `IEntityDataService`) into the `setRepository(BaseHibernateRepository repository)` method, it failed because it couldn't convert the proxy to `BaseHibernateRepository`.

### Java Version Difference
This worked on Java 11 because Spring's type conversion and proxy handling is more lenient in newer versions.

## Solution

Refactored both `DepositServiceImpl` and `DepositTransactionServiceImpl` to follow the same pattern as `BillServiceImpl`:

cc @Josh-Murunga @andrineM 