### PR TITLE
fix KHP3-8363 : Resolve issue where users without `VIEW DEPOSIT` privilege can create bills

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/IDepositService.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/IDepositService.java
@@ -33,7 +33,6 @@ public interface IDepositService extends IEntityDataService<Deposit> {
      * @should return the deposit with the specified id
      * @should return null if no deposit is found
      */
-    @Authorized(PrivilegeConstants.VIEW_DEPOSITS)
     Deposit getById(Integer depositId);
 
     /**
@@ -44,7 +43,6 @@ public interface IDepositService extends IEntityDataService<Deposit> {
      * @should return the deposit with the specified uuid
      * @should return null if no deposit is found
      */
-    @Authorized(PrivilegeConstants.VIEW_DEPOSITS)
     Deposit getByUuid(String uuid);
 
     /**
@@ -56,7 +54,6 @@ public interface IDepositService extends IEntityDataService<Deposit> {
      * @should return all deposits for the specified patient
      * @should return an empty list if the patient has no deposits
      */
-    @Authorized(PrivilegeConstants.VIEW_DEPOSITS)
     List<Deposit> getDepositsByPatient(Patient patient, PagingInfo pagingInfo);
 
     /**
@@ -68,7 +65,6 @@ public interface IDepositService extends IEntityDataService<Deposit> {
      * @should return all deposits for the specified patient
      * @should return an empty list if the patient has no deposits
      */
-    @Authorized(PrivilegeConstants.VIEW_DEPOSITS)
     List<Deposit> getDepositByPatientUuid(String patientUuid, PagingInfo pagingInfo);
 
     /**
@@ -79,7 +75,6 @@ public interface IDepositService extends IEntityDataService<Deposit> {
      * @should return the deposit with the specified reference number
      * @should return null if no deposit is found
      */
-    @Authorized(PrivilegeConstants.VIEW_DEPOSITS)
     Deposit getDepositByReferenceNumber(String referenceNumber);
 
     /**

--- a/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/IDepositTransactionService.java
+++ b/api/src/main/java/org/openmrs/module/kenyaemr/cashier/api/IDepositTransactionService.java
@@ -18,7 +18,6 @@ public interface IDepositTransactionService extends IEntityDataService<DepositTr
      * @should return all deposit transactions
      * @should return an empty list if no transactions are found
      */
-    @Authorized(PrivilegeConstants.VIEW_DEPOSITS)
     List<DepositTransaction> getAll(Boolean includeVoided);
 
     /**
@@ -37,7 +36,6 @@ public interface IDepositTransactionService extends IEntityDataService<DepositTr
      * @should return the deposit transaction with the specified id
      * @should return null if no deposit transaction is found
      */
-    @Authorized(PrivilegeConstants.VIEW_DEPOSITS)
     DepositTransaction getById(Integer depositTransactionId);
 
     /**
@@ -47,7 +45,6 @@ public interface IDepositTransactionService extends IEntityDataService<DepositTr
      * @should return the deposit transaction with the specified uuid
      * @should return null if no deposit transaction is found
      */
-    @Authorized(PrivilegeConstants.VIEW_DEPOSITS)
     DepositTransaction getByUuid(String uuid);
 
     /**


### PR DESCRIPTION
### Description

This should resolve https://thepalladiumgroup.atlassian.net/browse/KHP3-8363

The problem is that when creating a bill, the REST API is trying to serialize the bill object, which includes calling the `getTotalDeposits` method. This method calls `depositService.getDepositsByPatient()`, which requires the "View Deposits" privilege. Therefore for users without that privilege it was failing 